### PR TITLE
Replace `ClusterSelector` with `ClusterRef` and add support for provisioning into existing cluster.

### DIFF
--- a/cluster/charts/gitlab-controller/crds/controller/v1alpha1/gitlab.yaml
+++ b/cluster/charts/gitlab-controller/crds/controller/v1alpha1/gitlab.yaml
@@ -40,8 +40,9 @@ spec:
             clusterNamespace:
               description: ClusterNamespace
               type: string
-            clusterSelector:
-              description: ClusterSelector label based
+            clusterRef:
+              description: ClusterRef to a target kubernetes cluster where a GitLab
+                controller will deploy GitLab application components
               type: object
             domain:
               description: Domain which will contain records to resolve gitlab, registry,

--- a/cluster/examples/gitlab-controller.yaml
+++ b/cluster/examples/gitlab-controller.yaml
@@ -3,6 +3,7 @@ kind: GitLab
 metadata:
   name: demo
 spec:
+#  clusterRef:
   domain: my-domain.io
   hostSuffix: demo
   email: me@my-domain.io

--- a/pkg/apis/controller/v1alpha1/types.go
+++ b/pkg/apis/controller/v1alpha1/types.go
@@ -48,8 +48,9 @@ type GitLabSpec struct {
 	// ReclaimPolicy controls application cleanup
 	ReclaimPolicy xpcorev1alpha1.ReclaimPolicy `json:"reclaimPolicy,omitempty"`
 
-	// ClusterSelector label based
-	ClusterSelector *metav1.LabelSelector `json:"clusterSelector,omitempty"`
+	// ClusterRef to a target kubernetes cluster where a GitLab controller will
+	// deploy GitLab application components
+	ClusterRef *corev1.ObjectReference `json:"clusterRef,omitempty"`
 
 	// ClusterNamespace
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`
@@ -100,9 +101,9 @@ func (in *GitLab) GetClusterNamespace() string {
 	return in.Spec.ClusterNamespace
 }
 
-// GetClusterSelector spec property
-func (in *GitLab) GetClusterSelector() *metav1.LabelSelector {
-	return in.Spec.ClusterSelector
+// GetClusterRef spec property
+func (in *GitLab) GetClusterRef() *corev1.ObjectReference {
+	return in.Spec.ClusterRef
 }
 
 // GetEndpoint returns a gitlab service endpoint

--- a/pkg/apis/controller/v1alpha1/types_test.go
+++ b/pkg/apis/controller/v1alpha1/types_test.go
@@ -277,22 +277,22 @@ func TestGitLab_GetClusterNamespace(t *testing.T) {
 	}
 }
 
-func TestGitLab_GetClusterSelector(t *testing.T) {
+func TestGitLab_GetClusterRef(t *testing.T) {
 	tests := map[string]struct {
 		spec GitLabSpec
-		want *metav1.LabelSelector
+		want *corev1.ObjectReference
 	}{
 		"NoSelector": {spec: GitLabSpec{}, want: nil},
-		"Custom":     {spec: GitLabSpec{ClusterSelector: &metav1.LabelSelector{}}, want: &metav1.LabelSelector{}},
+		"Custom":     {spec: GitLabSpec{ClusterRef: &corev1.ObjectReference{}}, want: &corev1.ObjectReference{}},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			gl := &GitLab{
 				Spec: tt.spec,
 			}
-			got := gl.GetClusterSelector()
+			got := gl.GetClusterRef()
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("GitLab.GetClusterSelector() %s", diff)
+				t.Errorf("GitLab.GetClusterRef() %s", diff)
 			}
 		})
 	}

--- a/pkg/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -89,10 +89,10 @@ func (in *GitLabList) DeepCopyObject() runtime.Object {
 func (in *GitLabSpec) DeepCopyInto(out *GitLabSpec) {
 	*out = *in
 	out.ProviderRef = in.ProviderRef
-	if in.ClusterSelector != nil {
-		in, out := &in.ClusterSelector, &out.ClusterSelector
-		*out = new(v1.LabelSelector)
-		(*in).DeepCopyInto(*out)
+	if in.ClusterRef != nil {
+		in, out := &in.ClusterRef, &out.ClusterRef
+		*out = new(v1.ObjectReference)
+		**out = **in
 	}
 	return
 }

--- a/pkg/controller/gitlab/reconciler_test.go
+++ b/pkg/controller/gitlab/reconciler_test.go
@@ -151,6 +151,10 @@ func (b *gitlabBuilder) withMeta(meta metav1.ObjectMeta) *gitlabBuilder {
 	b.ObjectMeta = meta
 	return b
 }
+func (b *gitlabBuilder) withSpecClusterRef(ref *corev1.ObjectReference) *gitlabBuilder {
+	b.GitLab.Spec.ClusterRef = ref
+	return b
+}
 func (b *gitlabBuilder) withSpecDomain(domain string) *gitlabBuilder {
 	b.GitLab.Spec.Domain = domain
 	return b


### PR DESCRIPTION
The initial implementation had partial support for `ClusterSelector`: while the Spec property was defined, the controller ignored the selector and provisioned new `KuberentesCluster` resource every time.

This change replaces `ClusterSelector` with `ClusterRef` - ObjectReference, and provided an implementation that will treat the existing Kubernetes cluster as a resource. 