### PR TITLE
Properly handle resource reconciliation status.

### DIFF
--- a/pkg/controller/gitlab/reconciler.go
+++ b/pkg/controller/gitlab/reconciler.go
@@ -270,8 +270,17 @@ func (r *gitLabReconciler) reconcile(ctx context.Context) (reconcile.Result, err
 
 	log.V(logging.Debug).Info("reconciling resource claims")
 	res, err := r.resourceClaimsReconciler.reconcile(ctx, r.resourceClaims)
-	if res != reconcileSuccess {
+	if err != nil {
 		log.Error(err, "claim reconciliation failed")
+		return res, err
+	}
+
+	switch res {
+	case reconcileFailure:
+		log.Info("one or more claims have failed status", "reconcile action", "rerun")
+		return res, err
+	case reconcileWait:
+		log.Info("one or more claims have pending status", "reconcile action", "wait")
 		return res, err
 	}
 

--- a/pkg/controller/gitlab/reconciler_test.go
+++ b/pkg/controller/gitlab/reconciler_test.go
@@ -1145,7 +1145,7 @@ func Test_gitLabReconciler_reconcile(t *testing.T) {
 		fields fields
 		want   want
 	}{
-		"FailureReconcilingResourceClaims": {
+		"ReconcileResourceClaimsWithError": {
 			fields: fields{
 				gitlab: newGitLabBuilder().withMeta(testMeta).withSpecDomain(testDomain).build(),
 				claimsReconciler: &mockComponentsReconciler{
@@ -1157,6 +1157,34 @@ func Test_gitLabReconciler_reconcile(t *testing.T) {
 			want: want{
 				res: reconcileFailure,
 				err: testError,
+			},
+		},
+		"ReconcileResourceClaimsWithFailedStatus": {
+			fields: fields{
+				gitlab: newGitLabBuilder().withMeta(testMeta).withSpecDomain(testDomain).build(),
+				claimsReconciler: &mockComponentsReconciler{
+					mockReconcile: func(ctx context.Context, reconcilers []resourceReconciler) (reconcile.Result, error) {
+						return reconcileFailure, nil
+					},
+				},
+			},
+			want: want{
+				res: reconcileFailure,
+				err: nil,
+			},
+		},
+		"ReconcileResourceClaimsWithPendingStatus": {
+			fields: fields{
+				gitlab: newGitLabBuilder().withMeta(testMeta).withSpecDomain(testDomain).build(),
+				claimsReconciler: &mockComponentsReconciler{
+					mockReconcile: func(ctx context.Context, reconcilers []resourceReconciler) (reconcile.Result, error) {
+						return reconcileWait, nil
+					},
+				},
+			},
+			want: want{
+				res: reconcileWait,
+				err: nil,
 			},
 		},
 		"FailureReconcilingApplications": {


### PR DESCRIPTION
Currently, reconciler will report an error on any status other than `reconcileSuccess`.

Note: this fix is most likely transient and I expect this behavior to change after we merge `helm` + `application` functionality.