### PR TITLE
Set Helm release namespace to 'default'

### DIFF
--- a/pkg/controller/gitlab/resource/helm/fixtures/simple/templates/ingress.yaml
+++ b/pkg/controller/gitlab/resource/helm/fixtures/simple/templates/ingress.yaml
@@ -4,6 +4,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  {{- if .Values.setNamespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/pkg/controller/gitlab/resource/helm/fixtures/simple/templates/service.yaml
+++ b/pkg/controller/gitlab/resource/helm/fixtures/simple/templates/service.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "simple.fullname" . }}
+  {{- if .Values.setNamespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/pkg/controller/gitlab/resource/helm/helm.go
+++ b/pkg/controller/gitlab/resource/helm/helm.go
@@ -67,6 +67,15 @@ func WithReleaseName(name string) Option {
 	}
 }
 
+// WithReleaseNamespace configures the Helm release namespace used to render
+// resources.
+func WithReleaseNamespace(namespace string) Option {
+	return func(o *options) error {
+		o.namespace = namespace
+		return nil
+	}
+}
+
 // WithValues configures the Helm values used to render resources.
 func WithValues(v chartutil.Values) Option {
 	return func(o *options) error {
@@ -112,10 +121,13 @@ func Render(chartURL string, o ...Option) ([]*unstructured.Unstructured, error) 
 
 	ro := renderutil.Options{
 		ReleaseOptions: chartutil.ReleaseOptions{
-			// Namespace can be set here, but it seems to be ignored.
+			// Namespace can be set here, but is only used in cases where a
+			// template explicitly references {{ .Release.Namespace }} and will
+			// not affect the namespace in which resources are actually created.
 			// https://github.com/helm/helm/issues/3553
-			Name: opts.name,
-			Time: timeconv.Now(),
+			Namespace: opts.namespace,
+			Name:      opts.name,
+			Time:      timeconv.Now(),
 		},
 		KubeVersion: fmt.Sprintf("%s.%s", chartutil.DefaultKubeVersion.Major, chartutil.DefaultKubeVersion.Minor),
 	}


### PR DESCRIPTION
This is a little confusing, as it only applies when chart templates reference the `.Release.Namespace` value, which most do not actually use to set their namespace.

Fixes #11 