### PR TITLE
Disable unicorn tests and runner caching

### DIFF
--- a/pkg/controller/gitlab/reconciler.go
+++ b/pkg/controller/gitlab/reconciler.go
@@ -296,6 +296,11 @@ func (a *applicationReconciler) getHelmValues(ctx context.Context, rr []resource
 			valuesKeyMinio: chartutil.Values{"enabled": false},
 			"hosts":        chartutil.Values{"domain": a.Spec.Domain},
 		},
+		valuesKeyGitlab: chartutil.Values{
+			"unicorn": chartutil.Values{
+				"helmTests": chartutil.Values{"enabled": false},
+			},
+		},
 		valuesKeyPostgres:    chartutil.Values{"install": false},
 		valuesKeyRedis:       chartutil.Values{"enabled": false},
 		valuesKeyPrometheus:  chartutil.Values{"install": false},

--- a/pkg/controller/gitlab/reconciler.go
+++ b/pkg/controller/gitlab/reconciler.go
@@ -81,6 +81,7 @@ const (
 	valuesKeyPostgres    = "postgresql" // Postgres is configured at .postgres
 	valuesKeyPSQL        = "psql"       // ...and at .global.psql
 	valuesKeyPrometheus  = "prometheus"
+	valuesKeyRunner      = "gitlab-runner"
 )
 
 var (
@@ -299,6 +300,12 @@ func (a *applicationReconciler) getHelmValues(ctx context.Context, rr []resource
 		valuesKeyGitlab: chartutil.Values{
 			"unicorn": chartutil.Values{
 				"helmTests": chartutil.Values{"enabled": false},
+			},
+		},
+		valuesKeyRunner: chartutil.Values{
+			"runners": chartutil.Values{
+				// Disable the runner cache.
+				"cache": chartutil.Values{},
 			},
 		},
 		valuesKeyPostgres:    chartutil.Values{"install": false},


### PR DESCRIPTION
The former isn't necessary, and the latter is optional.