### PR TITLE
Skip scheduling and deploy our KubeApp to the cluster we selected

### DIFF
--- a/pkg/controller/gitlab/application/application_test.go
+++ b/pkg/controller/gitlab/application/application_test.go
@@ -35,6 +35,7 @@ var (
 	labels          = map[string]string{"cool": "very"}
 	annotations     = map[string]string{"cool.io/enabled": "true"}
 	clusterSelector = &metav1.LabelSelector{MatchLabels: map[string]string{"isitacluster": "yes"}}
+	cluster         = &corev1.ObjectReference{Name: name}
 )
 
 var (
@@ -107,6 +108,7 @@ func TestProduce(t *testing.T) {
 					WithLabels(labels),
 					WithAnnotations(annotations),
 					WithClusterSelector(clusterSelector),
+					WithCluster(cluster),
 					WithControllerReference(ownerRef),
 				},
 			},
@@ -146,6 +148,7 @@ func TestProduce(t *testing.T) {
 						},
 					},
 				},
+				Status: xpworkloadv1alpha1.KubernetesApplicationStatus{Cluster: cluster},
 			},
 		},
 		{

--- a/pkg/controller/gitlab/postgres.go
+++ b/pkg/controller/gitlab/postgres.go
@@ -41,6 +41,7 @@ const (
 type postgresReconciler struct {
 	*baseResourceReconciler
 	resourceClassFinder resourceClassFinder
+	ref                 *corev1.ObjectReference
 }
 
 func (r *postgresReconciler) reconcile(ctx context.Context) error {
@@ -67,11 +68,22 @@ func (r *postgresReconciler) reconcile(ctx context.Context) error {
 	}
 
 	r.status = &pg.Status
+	r.ref = &corev1.ObjectReference{
+		Kind:       pg.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion: pg.GetObjectKind().GroupVersionKind().Version,
+		Namespace:  pg.GetNamespace(),
+		Name:       pg.GetName(),
+		UID:        pg.GetUID(),
+	}
 	return nil
 }
 
 func (r *postgresReconciler) getClaimKind() string {
 	return postgresqlClaimKind
+}
+
+func (r *postgresReconciler) getClaimRef() *corev1.ObjectReference {
+	return r.ref
 }
 
 func (r *postgresReconciler) getHelmValues(ctx context.Context, dst chartutil.Values, secretPrefix string) error {

--- a/pkg/controller/gitlab/reconciler_test.go
+++ b/pkg/controller/gitlab/reconciler_test.go
@@ -100,6 +100,7 @@ type mockResourceReconciler struct {
 	mockIsReady                      func() bool
 	mockIsFailed                     func() bool
 	mockGetClaimKind                 func() string
+	mockGetClaimRef                  func() *corev1.ObjectReference
 	mockGetClaimConnectionSecretName func() string
 	mockGetClaimConnectionSecret     func(context.Context) (*corev1.Secret, error)
 	mockGetHelmValues                func(context.Context, chartutil.Values, string) error
@@ -116,6 +117,9 @@ func (m *mockResourceReconciler) isFailed() bool {
 }
 func (m *mockResourceReconciler) getClaimKind() string {
 	return m.mockGetClaimKind()
+}
+func (m *mockResourceReconciler) getClaimRef() *corev1.ObjectReference {
+	return m.mockGetClaimRef()
 }
 func (m *mockResourceReconciler) getClaimConnectionSecretName() string {
 	return m.mockGetClaimConnectionSecretName()

--- a/pkg/controller/gitlab/redis.go
+++ b/pkg/controller/gitlab/redis.go
@@ -40,6 +40,7 @@ const (
 type redisReconciler struct {
 	*baseResourceReconciler
 	resourceClassFinder resourceClassFinder
+	ref                 *corev1.ObjectReference
 }
 
 func (r *redisReconciler) reconcile(ctx context.Context) error {
@@ -66,11 +67,22 @@ func (r *redisReconciler) reconcile(ctx context.Context) error {
 	}
 
 	r.status = &red.Status
+	r.ref = &corev1.ObjectReference{
+		Kind:       red.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion: red.GetObjectKind().GroupVersionKind().Version,
+		Namespace:  red.GetNamespace(),
+		Name:       red.GetName(),
+		UID:        red.GetUID(),
+	}
 	return nil
 }
 
 func (r *redisReconciler) getClaimKind() string {
 	return redisClaimKind
+}
+
+func (r *redisReconciler) getClaimRef() *corev1.ObjectReference {
+	return r.ref
 }
 
 func (r *redisReconciler) getHelmValues(ctx context.Context, dst chartutil.Values, secretPrefix string) error {


### PR DESCRIPTION
I feel like this isn't a good idea long term, but for the moment this should ensure the `KubernetesApplication` is deployed to the correct cluster, rather than leaving it up to the whim of the `KubernetesApplication` scheduler when multiple clusters exist.