### PR TITLE
Use the unicorn deployment readiness as an indicator of Gitlab readiness

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1576,6 +1576,7 @@
     "golang.org/x/net/context",
     "gopkg.in/alecthomas/kingpin.v2",
     "gopkg.in/yaml.v2",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",


### PR DESCRIPTION
Unicorn is Gitlab's primary web frontend. It having available pods is not a guarantee that Gitlab is ready, but it's a passable indicator. Gitlab has many moving pieces (services, ingresses, ingress controller, external DNS, runners, etc) and we should consider them all in determining application readiness but this should do as a start. 