### PR TITLE
Revert "If we're ready, we're probably not pending or failed."

### DIFF
--- a/pkg/controller/gitlab/reconciler.go
+++ b/pkg/controller/gitlab/reconciler.go
@@ -441,7 +441,6 @@ func (a *applicationReconciler) reconcile(ctx context.Context, rr []resourceReco
 			"namespace", a.GetNamespace(),
 			"name", a.GetName())
 		if a.isReady(ctx) {
-			a.GitLab.Status.UnsetAllConditions()
 			a.SetReady()
 			return reconcileSuccess, a.update(ctx)
 		}
@@ -493,7 +492,6 @@ func (a *applicationReconciler) reconcile(ctx context.Context, rr []resourceReco
 	}
 
 	if a.isReady(ctx) {
-		a.GitLab.Status.UnsetAllConditions()
 		a.SetReady()
 		return reconcileSuccess, a.update(ctx)
 	}


### PR DESCRIPTION
Reverts crossplaneio/gitlab-controller#21

Turns out this was already being done under the hood.