### PR TITLE
governance: add OWNERS.md to define maintainers of this repo

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,31 +1,13 @@
-# GitLab-Controller Maintainers
+# OWNERS
 
-This page lists all active maintainers and their areas of expertise. This can be used for routing PRs, questions, etc. to the right place.
+This page lists all maintainers for **this** repository. Each repository in the [Crossplane
+organization](https://github.com/crossplane/) will list their repository maintainers in their own
+`OWNERS.md` file.
 
-* See [CONTRIBUTING.md](CONTRIBUTING.md) for general contribution guidelines.
-* See [GOVERNANCE.md](GOVERNANCE.md) for governance guidelines and maintainer responsibilities.
-
-## Senior maintainers
-
-Here's the current list of senior maintainers:
-
-* Bassam Tabbara <bassam@upbound.io> ([bassam](https://github.com/bassam))
-  * Catch-all, architecture, strategy, build and packaging
-* Illya Chekrygin <illya@upbound.io> ([ichekrygin](https://github.com/ichekrygin))
-  * Core, Controllers, GCP, AWS, Azure
-* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
-  * Core, Controllers, GCP, AWS, Azure
+Please see the Crossplane
+[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
+guidelines and responsibilities for the steering committee and maintainers.
 
 ## Maintainers
 
-There are currently no maintainers. Maintainers will be added according to the [process for adding a maintainer](GOVERNANCE.md#becoming-a-maintainer) in the [governance](GOVERNANCE.md).
-
-## Emeritus maintainers
-
-There are currently no emeritus maintainers.  This list will be updated according to the [process for removing a maintainer](GOVERNANCE.md#removing-a-maintainer) in the [governance](GOVERNANCE.md).
-
-## Friends of GitLab-Controller
-
-This section lists people that are not currently maintainers but have demonstrated value to the community.
-They typically help out with technical, code and design reviews and also with support and troubleshooting.
-Feel free to loop them in as needed.
+* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))


### PR DESCRIPTION
### Description of your changes

This PR adds an OWNERS.md file that defines the current maintainers of this repository.  The roles and responsibilities of maintainers are defined in Crossplane
[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md).

[skip ci]